### PR TITLE
Avoid Mapnik update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "mapnik-omnivore": "^6.0.0",
-    "tilelive-bridge": "^1.2.7",
+    "mapnik-omnivore": "~6.0.0",
+    "tilelive-bridge": "~1.2.7",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Need to pin some dependencies to avoid Mapnik dupes.