### PR TITLE
Avoid Mapnik dupes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "mapnik-omnivore": "~6.0.0",
+    "mapnik-omnivore": "~6.1.0",
     "tilelive-bridge": "~1.2.7",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "mapnik-omnivore": "^6.0.0",
-    "tilelive-bridge": "^1.2.7",
+    "mapnik-omnivore": "~6.0.0",
+    "tilelive-bridge": "~1.2.7",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Only allow Mapnik 3.2.0 to avoid bugs in Mapnik 3.3.0 via `tilelive-bridge`. Also new bug fixes in `mapnik-omnivore`