### PR TITLE
Add command line tool: given a file, generate xml

### DIFF
--- a/bin/generate_xml.js
+++ b/bin/generate_xml.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var Omnivore = require('..');
+var getMetadata = require('mapnik-omnivore').digest;
+
+var usage = 'usage: generate-xml.js <filepath>';
+
+var filepath = process.argv[2];
+
+if (!filepath) {
+   console.log(usage);
+   process.exit(1);
+}
+
+getMetadata(filepath, function(err,metadata) {
+    if (err) throw err;
+    metadata.filepath = filepath;
+    console.log(Omnivore.getXml(metadata));
+});

--- a/bin/mapnik-omnivore
+++ b/bin/mapnik-omnivore
@@ -5,7 +5,7 @@
 var Omnivore = require('..');
 var getMetadata = require('mapnik-omnivore').digest;
 
-var usage = 'usage: generate-xml.js <filepath>';
+var usage = 'usage: mapnik-omnivore <filepath>';
 
 var filepath = process.argv[2];
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "tilelive-bridge": "~2.2.1",
     "underscore": "^1.7.0"
   },
+  "bin": {
+    "mapnik-omnivore": "bin/mapnik-omnivore"
+  },
   "devDependencies": {
     "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz",
     "queue-async": "^1.0.7",

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,14 @@ new Omnivore(uri, function(err, source) {
 });
 ```
 
+Using the command line will output the XML directly to your shell.
+
+```bash
+mapnik-omnivore <filepath>
+```
+
 ## Works with
 
 any file supported by [mapnik-omnivore](https://github.com/mapbox/mapnik-omnivore)
+
+## Command Line

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,8 @@ var datasets = require('./datasets');
 var Omnivore = require('..');
 var queue = require('queue-async');
 var tilelive = require('tilelive');
+var OmnivoreBin = path.resolve(__dirname, '..', 'bin', 'mapnik-omnivore');
+var spawn = require('child_process').spawn;
 
 test('should set protocol as we would like', function(assert) {
     var fake_tilelive = {
@@ -131,4 +133,50 @@ test('getTile returns tiles for geojson source', function(t) {
       });
     });
   });
+});
+
+// test CLI command `mapnik-omnivore`
+test('[bin/mapnik-omnivore] errors if not passed valid path', function(assert) {
+  var args = [OmnivoreBin];
+
+  spawn(process.execPath, args)
+    .on('error', function(err) {
+      assert.ok(err, 'should error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 1, 'exit 1');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
+});
+
+test('[bin/mapnik-omnivore] runs on an absolute file path', function(assert) {
+  var args = [OmnivoreBin, datasets.geojson];
+
+  spawn(process.execPath, args)
+    .on('error', function(err) {
+      assert.ifError(err, 'should not error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 0, 'exit 0');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
+});
+
+test('[bin/mapnik-omnivore] runs on a relative file path', function(assert) {
+  var options = {
+    cwd: path.resolve(__dirname, '..', 'node_modules')
+  };
+  var args = [OmnivoreBin, path.relative(options.cwd, datasets.geojson)];
+
+  spawn(process.execPath, args, options)
+    .on('error', function(err) {
+      assert.ifError(err, 'should not error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 0, 'exit 0');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
 });


### PR DESCRIPTION
/cc @rclark @GretaCB 

Just found myself in need of this. Does this seem like a nice addition? Or does it duplicate functionality somewhere else that I might have missed?

Idea is to quickly generate the XML `tilelive-copy` + `tilelive-bridge` needs on the command line. This is useful when you want to hand edit the XML later on to adjust the export settings for debugging.

```sh
$ node bin/generate_xml.js ~/data/box.json
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE Map[]>
<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
  <Parameters>
    <Parameter name="center">-101.6015625,42.72699658492618,0</Parameter>
    <Parameter name="bounds">-159.609375,9.102096738726456,-43.59375,76.3518964311259</Parameter>
    <Parameter name="format">pbf</Parameter>
    <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"box","description":"","minzoom":0,"maxzoom":22,"fields":{"application_count_all_chemical":"Number","application_count_fumigants":"Number","id":"Number","top_chemicals":"String","total_lbs_used_all_chemical":"Number","total_lbs_used_fumigants_chemical":"Number"}}]}]]></Parameter>
    <Parameter name="maxzoom">2</Parameter>
    <Parameter name="minzoom">0</Parameter>
  </Parameters>
  
  
  <Layer name="box" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
    
    <Datasource>
      <Parameter name="type">geojson</Parameter>
      <Parameter name="file">/Users/dane/data/box.json</Parameter>
      <Parameter name="layer">box</Parameter>
      <Parameter name="cache_features">false</Parameter>
    </Datasource>
  </Layer>
  
</Map>
```

