### PR TITLE
update node mapnik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/bin/mapnik-omnivore
+++ b/bin/mapnik-omnivore
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var Omnivore = require('..');
+var getMetadata = require('mapnik-omnivore').digest;
+
+var usage = 'usage: mapnik-omnivore <filepath>';
+
+var filepath = process.argv[2];
+
+if (!filepath) {
+   console.log(usage);
+   process.exit(1);
+}
+
+getMetadata(filepath, function(err,metadata) {
+    if (err) throw err;
+    metadata.filepath = filepath;
+    console.log(Omnivore.getXml(metadata));
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "tilelive-bridge": "~2.2.1",
     "underscore": "^1.7.0"
   },
+  "bin": {
+    "mapnik-omnivore": "bin/mapnik-omnivore"
+  },
   "devDependencies": {
     "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz",
     "queue-async": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mapnik-omnivore": "bin/mapnik-omnivore"
   },
   "devDependencies": {
-    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz",
+    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.1.1-d1476b261f018c28f08c573de3c9885386f52315.tgz",
     "queue-async": "^1.0.7",
     "tape": "^3.0.1",
     "tilelive": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
     "mapnik-omnivore": "~7.1.0",
-    "tilelive-bridge": "~2.2.1",
+    "tilelive-bridge": "https://github.com/mapbox/tilelive-bridge/tarball/mapnik-v2_spec",
     "underscore": "^1.7.0"
   },
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,14 @@ new Omnivore(uri, function(err, source) {
 });
 ```
 
+Using the command line will output the XML directly to your shell.
+
+```bash
+mapnik-omnivore <filepath>
+```
+
 ## Works with
 
 any file supported by [mapnik-omnivore](https://github.com/mapbox/mapnik-omnivore)
+
+## Command Line

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,8 @@ var datasets = require('./datasets');
 var Omnivore = require('..');
 var queue = require('queue-async');
 var tilelive = require('tilelive');
+var OmnivoreBin = path.resolve(__dirname, '..', 'bin', 'mapnik-omnivore');
+var spawn = require('child_process').spawn;
 
 test('should set protocol as we would like', function(assert) {
     var fake_tilelive = {
@@ -131,4 +133,50 @@ test('getTile returns tiles for geojson source', function(t) {
       });
     });
   });
+});
+
+// test CLI command `mapnik-omnivore`
+test('[bin/mapnik-omnivore] errors if not passed valid path', function(assert) {
+  var args = [OmnivoreBin];
+
+  spawn(process.execPath, args)
+    .on('error', function(err) {
+      assert.ok(err, 'should error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 1, 'exit 1');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
+});
+
+test('[bin/mapnik-omnivore] runs on an absolute file path', function(assert) {
+  var args = [OmnivoreBin, datasets.geojson];
+
+  spawn(process.execPath, args)
+    .on('error', function(err) {
+      assert.ifError(err, 'should not error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 0, 'exit 0');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
+});
+
+test('[bin/mapnik-omnivore] runs on a relative file path', function(assert) {
+  var options = {
+    cwd: path.resolve(__dirname, '..', 'node_modules')
+  };
+  var args = [OmnivoreBin, path.relative(options.cwd, datasets.geojson)];
+
+  spawn(process.execPath, args, options)
+    .on('error', function(err) {
+      assert.ifError(err, 'should not error');
+    })
+    .on('close', function(code) {
+      assert.equal(code, 0, 'exit 0');
+      assert.end();
+    })
+    .stderr.pipe(process.stdout);
 });


### PR DESCRIPTION
Incorporating changes in `tilelive-bridge` from https://github.com/mapbox/tilelive-bridge/pull/76 to prepare for `node-mapnik` `3.5.0` release.