### PR TITLE
Layer name override

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "no-console": [0],
+    "semi": [2, "always"]
+  },
+  "env": {
+      "node": true
+  },
+  "globals": {
+      "process": true,
+      "module": true,
+      "require": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 npm-debug.log
+.nyc_output/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ addons:
      - ubuntu-toolchain-r-test
     packages:
      - libstdc++6 # upgrade libstdc++ on linux to support C++11
-
-after_success:
- - if [[ ${TRAVIS_NODE_VERSION} == "0.10" ]]; then npm run coverage; fi;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = Omnivore;
 
 function Omnivore(uri, callback) {
   uri = url.parse(uri);
-  var filepath = path.resolve(uri.pathname);
+  var filepath = path.resolve(decodeURI(uri.pathname));
   var omnivore = this;
 
   getMetadata(filepath, getXml);
@@ -41,7 +41,7 @@ function Omnivore(uri, callback) {
 }
 
 Omnivore.registerProtocols = function(tilelive) {
-    tilelive.protocols['omnivore:'] = Omnivore;
+  tilelive.protocols['omnivore:'] = Omnivore;
 };
 
 Omnivore.getXml = function(metadata) {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Implements the tilelive API for a variety of raw data formats",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/index.js",
-    "coverage": "istanbul cover tape test/index.js && coveralls < ./coverage/lcov.info"
+    "test": "nyc tape test/index.js",
+    "coverage": "nyc --reporter=html tape test/index.js && opener coverage/index.html"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,12 @@
     "mapnik-omnivore": "bin/mapnik-omnivore"
   },
   "devDependencies": {
+    "eslint": "^2.4.0",
     "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.1.1-d1476b261f018c28f08c573de3c9885386f52315.tgz",
+    "nyc": "^6.0.0",
+    "opener": "^1.4.1",
     "queue-async": "^1.0.7",
     "tape": "^3.0.1",
-    "tilelive": "^5.11.0",
-    "istanbul": "~0.3.17",
-    "coveralls": "~2.11.2"
+    "tilelive": "^5.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Implements the tilelive API for a variety of raw data formats",
   "main": "index.js",
   "scripts": {
+    "pretest": "eslint index.js test bin",
     "test": "nyc tape test/index.js",
     "coverage": "nyc --reporter=html tape test/index.js && opener coverage/index.html"
   },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.1.1-d1476b261f018c28f08c573de3c9885386f52315.tgz",
     "nyc": "^6.0.0",
     "opener": "^1.4.1",
+    "pbf": "^1.3.5",
     "queue-async": "^1.0.7",
     "tape": "^3.0.1",
-    "tilelive": "^5.11.0"
+    "tilelive": "^5.11.0",
+    "vector-tile": "^1.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,6 @@
 Implements the tilelive api for a variety of raw data sources
 
 [![Build Status](https://travis-ci.org/mapbox/tilelive-omnivore.svg?branch=master)](https://travis-ci.org/mapbox/tilelive-omnivore)
-[![Coverage Status](https://coveralls.io/repos/mapbox/tilelive-omnivore/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/tilelive-omnivore?branch=master)
 
 ## Install
 

--- a/template.xml
+++ b/template.xml
@@ -11,14 +11,14 @@
   </Parameters>
   <% _.each(layers, function(l) { %>
   <% if (l.type === 'gdal') { %>
-  <Style name="<%= l.layer %>" filter-mode="first">
+  <Style name="<%= l.name %>" filter-mode="first">
     <Rule>
       <RasterSymbolizer opacity="1" scaling="bilinear" />
     </Rule>
   </Style>
   <% } %>
-  <Layer name="<%= l.layer %>" buffer-size="<% if (l.type === 'gdal') { %>0<% } else { %>8<% } %>" srs="<%= projection %>">
-    <% if (l.type === 'gdal') { %><StyleName><%= l.layer %></StyleName><% } %>
+  <Layer name="<%= l.name %>" buffer-size="<% if (l.type === 'gdal') { %>0<% } else { %>8<% } %>" srs="<%= projection %>">
+    <% if (l.type === 'gdal') { %><StyleName><%= l.name %></StyleName><% } %>
     <Datasource>
       <Parameter name="type"><%= l.type %></Parameter>
       <Parameter name="file"><%= l.file %></Parameter>

--- a/test/expected/csv.mapnik.named.xml
+++ b/test/expected/csv.mapnik.named.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+  <Parameters>
+    <Parameter name="center">-77.0481382917019,38.93765872502635,0</Parameter>
+    <Parameter name="bounds">-77.0925920175155,38.9142786070481,-77.0036845658883,38.9610388430046</Parameter>
+    <Parameter name="format">pbf</Parameter>
+    <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"named","description":"","minzoom":0,"maxzoom":22,"fields":{"BBL_LICENSE_FACT_ID":"Number","LICENSESTATUS":"String","LICENSECATEGORY":"String","CUST_NUM":"Number","TRADE_NAME":"String","LICENSE_START_DATE":"String","LICENSE_EXPIRATION_DATE":"String","LICENSE_ISSUE_DATE":"String","AGENT_PHONE":"String","LASTMODIFIEDDATE":"String","CITY":"String","STATE":"String","SITEADDRESS":"String","LATITUDE":"Number","LONGITUDE":"Number","ZIPCODE":"Number","MARADDRESSREPOSITORYID":"Number","DCSTATADDRESSKEY":"Number","DCSTATLOCATIONKEY":"Number","WARD":"Number","ANC":"String","SMD":"String","DISTRICT":"String","PSA":"Number","NEIGHBORHOODCLUSTER":"Number","HOTSPOT2006NAME":"String","HOTSPOT2005NAME":"String","HOTSPOT2004NAME":"String","BUSINESSIMPROVEMENTDISTRICT":"String"}}]}]]></Parameter>
+    <Parameter name="maxzoom">11</Parameter>
+    <Parameter name="minzoom">0</Parameter>
+  </Parameters>
+  
+  
+  <Layer name="named" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    
+    <Datasource>
+      <Parameter name="type">csv</Parameter>
+      <Parameter name="file">[FILEPATH]</Parameter>
+      <Parameter name="layer">bbl_current_csv</Parameter>
+      
+    </Datasource>
+  </Layer>
+  
+</Map>

--- a/test/expected/geojson.mapnik.named.xml
+++ b/test/expected/geojson.mapnik.named.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+  <Parameters>
+    <Parameter name="center">-77.01335,38.89255,0</Parameter>
+    <Parameter name="bounds">-77.1174,38.7912,-76.9093,38.9939</Parameter>
+    <Parameter name="format">pbf</Parameter>
+    <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"named","description":"","minzoom":0,"maxzoom":22,"fields":{"kind":"String","name":"String","state":"String"}}]}]]></Parameter>
+    <Parameter name="maxzoom">6</Parameter>
+    <Parameter name="minzoom">0</Parameter>
+  </Parameters>
+  
+  
+  <Layer name="named" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    
+    <Datasource>
+      <Parameter name="type">geojson</Parameter>
+      <Parameter name="file">[FILEPATH]</Parameter>
+      <Parameter name="layer">DC_polygon.geo</Parameter>
+      <Parameter name="cache_features">false</Parameter>
+    </Datasource>
+  </Layer>
+  
+</Map>

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -4,5 +4,7 @@ var path = require('path');
 module.exports = ['csv', 'geojson', 'gpx', 'kml', 'shp', 'tif']
   .reduce(function(memo, type) {
     memo[type] = fs.readFileSync(path.resolve(__dirname, type + '.mapnik.xml'), 'utf8');
+    if (!(type === 'gpx' || type === 'kml'))
+      memo[type + '.named'] = fs.readFileSync(path.resolve(__dirname, type + '.mapnik.named.xml'), 'utf8');
     return memo;
   }, {});

--- a/test/expected/shp.mapnik.named.xml
+++ b/test/expected/shp.mapnik.named.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+  <Parameters>
+    <Parameter name="center">0,12.048603815490733,0</Parameter>
+    <Parameter name="bounds">-180,-59.47306100000001,180,83.57026863098147</Parameter>
+    <Parameter name="format">pbf</Parameter>
+    <Parameter name="json"><![CDATA[{"vector_layers":[{"id":"named","description":"","minzoom":0,"maxzoom":22,"fields":{"FIPS":"String","ISO2":"String","ISO3":"String","UN":"Number","NAME":"String","AREA":"Number","POP2005":"Number","REGION":"Number","SUBREGION":"Number","LON":"Number","LAT":"Number"}}]}]]></Parameter>
+    <Parameter name="maxzoom">5</Parameter>
+    <Parameter name="minzoom">0</Parameter>
+  </Parameters>
+  
+  
+  <Layer name="named" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    
+    <Datasource>
+      <Parameter name="type">shape</Parameter>
+      <Parameter name="file">[FILEPATH]</Parameter>
+      <Parameter name="layer">world_merc</Parameter>
+      
+    </Datasource>
+  </Layer>
+  
+</Map>

--- a/test/expected/tif.mapnik.named.xml
+++ b/test/expected/tif.mapnik.named.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+  <Parameters>
+    <Parameter name="center">-110.32476292309875,44.56502238336985,9</Parameter>
+    <Parameter name="bounds">-110.3650933429331,44.53327824851143,-110.28443250326441,44.596766518228264</Parameter>
+    <Parameter name="format">webp</Parameter>
+    
+    <Parameter name="maxzoom">15</Parameter>
+    <Parameter name="minzoom">9</Parameter>
+  </Parameters>
+  
+  
+  <Style name="named" filter-mode="first">
+    <Rule>
+      <RasterSymbolizer opacity="1" scaling="bilinear" />
+    </Rule>
+  </Style>
+  
+  <Layer name="named" buffer-size="0" srs="+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs">
+    <StyleName>named</StyleName>
+    <Datasource>
+      <Parameter name="type">gdal</Parameter>
+      <Parameter name="file">[FILEPATH]</Parameter>
+      <Parameter name="layer">sample</Parameter>
+      
+    </Datasource>
+  </Layer>
+  
+</Map>

--- a/test/index.js
+++ b/test/index.js
@@ -12,16 +12,16 @@ var OmnivoreBin = path.resolve(__dirname, '..', 'bin', 'mapnik-omnivore');
 var spawn = require('child_process').spawn;
 
 test('should set protocol as we would like', function(assert) {
-    var fake_tilelive = {
-        protocols: {}
-    };
-    Omnivore.registerProtocols(fake_tilelive);
-    assert.equal(fake_tilelive.protocols['omnivore:'],Omnivore);
-    assert.end();
+  var fake_tilelive = {
+    protocols: {}
+  };
+  Omnivore.registerProtocols(fake_tilelive);
+  assert.equal(fake_tilelive.protocols['omnivore:'],Omnivore);
+  assert.end();
 });
 
 test('metadata => xml', function(t) {
-  var xml, match, sanitized;
+  var xml;
   for (var type in fixtures) {
     xml = Omnivore.getXml(fixtures[type]);
     xml = xml.replace(
@@ -48,7 +48,6 @@ test('build bridges', function(t) {
   var q = queue();
 
   for (var type in datasets) {
-    var uri = 'omnivore://' + datasets[type];
     q.defer(testDataset, type);
   }
 


### PR DESCRIPTION
Allows the caller to override the output layer names in vector tiles by passing `layerName` query parameter to the URI. 

```
var uri = 'omnivore:///path/to/file.geojson?layerName=named';
new Omnivore(uri, function(err, src) { ... });
```

cc @BergWerkGIS I implemented eslint, adjusted coverage tools and fixed a few linting issues bringing the code more up-to-date with our current practices. Is this going to conflict with your work in #27? 

fixes #28 