### PR TITLE
fix "File not found" when use relative uri path

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function Omnivore(uri, callback) {
 
   var q = queue();
   files.forEach(function(file) {
+    if (uri.hostname === '.' || uri.hostname === '.') {
+      file = uri.hostname + file
+    }
     var filepath = path.resolve(file);
     q.defer(function(next) {
       getMetadata(filepath, function(err, metadata) {


### PR DESCRIPTION
when I exec:
```
tilelive-copy omnivore://./a.geojson mbtiles://./b.mbtiles
```
`./a.geojson` is resolved as /a.geojson, cause File not found