### PR TITLE
upgrade mapnik-omnivore, node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
- - "0.10"
- - "4.2.3"
+ - "4"
+ - "6"
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+- Upgraded to mapnik-omnivore@8.1.0 (includes gdal and mapnik releases)
+
 ## 3.0.0
 
 - Will no longer provide a recommended max zoom level less than 6

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/tag-fiesta",
+    "mapnik-omnivore": "~8.1.0",
     "queue-async": "^1.0.7",
     "tilelive-bridge": "~2.3.1",
     "underscore": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "mapnik-omnivore": "~8.0.0",
+    "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/tag-fiesta",
     "queue-async": "^1.0.7",
     "tilelive-bridge": "~2.3.1",
     "underscore": "^1.7.0"


### PR DESCRIPTION
* upgrades mapnik-omnivore
* updates node versions to v4 & v6, removes 0.10.x

cc @springmeyer @GretaCB @who8mycakes 