### PR TITLE
Default vector buffer size of 5

### DIFF
--- a/template.xml
+++ b/template.xml
@@ -17,7 +17,7 @@
     </Rule>
   </Style>
   <% } %>
-  <Layer name="<%= l.name %>" buffer-size="<% if (l.type === 'gdal') { %>0<% } else { %>8<% } %>" srs="<%= projection %>">
+  <Layer name="<%= l.name %>" buffer-size="<% if (l.type === 'gdal') { %>0<% } else { %>5<% } %>" srs="<%= projection %>">
     <% if (l.type === 'gdal') { %><StyleName><%= l.name %></StyleName><% } %>
     <Datasource>
       <Parameter name="type"><%= l.type %></Parameter>

--- a/test/expected/csv.mapnik.named.xml
+++ b/test/expected/csv.mapnik.named.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="named" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="named" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">csv</Parameter>

--- a/test/expected/csv.mapnik.xml
+++ b/test/expected/csv.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="bbl_current_csv" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="bbl_current_csv" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">csv</Parameter>

--- a/test/expected/geojson.mapnik.named.xml
+++ b/test/expected/geojson.mapnik.named.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="named" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="named" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">geojson</Parameter>

--- a/test/expected/geojson.mapnik.xml
+++ b/test/expected/geojson.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="DC_polygon.geo" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="DC_polygon.geo" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">geojson</Parameter>

--- a/test/expected/gpx.mapnik.xml
+++ b/test/expected/gpx.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="waypoints" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="waypoints" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -22,7 +22,7 @@
   </Layer>
   
   
-  <Layer name="routes" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="routes" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -33,7 +33,7 @@
   </Layer>
   
   
-  <Layer name="route_points" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="route_points" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>

--- a/test/expected/kml.mapnik.xml
+++ b/test/expected/kml.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="Magnitude 6" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 6" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -22,7 +22,7 @@
   </Layer>
   
   
-  <Layer name="Magnitude 5" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 5" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -33,7 +33,7 @@
   </Layer>
   
   
-  <Layer name="Magnitude 4" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 4" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -44,7 +44,7 @@
   </Layer>
   
   
-  <Layer name="Magnitude 3" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 3" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -55,7 +55,7 @@
   </Layer>
   
   
-  <Layer name="Magnitude 2" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 2" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>
@@ -66,7 +66,7 @@
   </Layer>
   
   
-  <Layer name="Magnitude 1" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="Magnitude 1" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">ogr</Parameter>

--- a/test/expected/multi-geojson.mapnik.xml
+++ b/test/expected/multi-geojson.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="DC_polygon.geo" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="DC_polygon.geo" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">geojson</Parameter>
@@ -22,7 +22,7 @@
   </Layer>
   
   
-  <Layer name="places.geo" buffer-size="8" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <Layer name="places.geo" buffer-size="5" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
     
     <Datasource>
       <Parameter name="type">geojson</Parameter>

--- a/test/expected/shp.mapnik.named.xml
+++ b/test/expected/shp.mapnik.named.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="named" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="named" buffer-size="5" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
     
     <Datasource>
       <Parameter name="type">shape</Parameter>

--- a/test/expected/shp.mapnik.xml
+++ b/test/expected/shp.mapnik.xml
@@ -11,7 +11,7 @@
   </Parameters>
   
   
-  <Layer name="world_merc" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="world_merc" buffer-size="5" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
     
     <Datasource>
       <Parameter name="type">shape</Parameter>


### PR DESCRIPTION
Our current buffer size is 8, which means we expand the clipping extent by 128 pixels (or 8*16) in the coordinate space of vector tiles (the default is 4096). This is more than tippecanoe, which uses a default of 5. A smaller buffer size will result in smaller tiles and a higher incidence of cut off labels in tiled rendering scenario. However the future of GL is moving to viewport based labeling so buffers are less critical for that case: https://github.com/mapbox/mapbox-gl-js/issues/4704.