### PR TITLE
Bump to 4.0.0, update deps for mapnik 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.0
+
+- Updated mapnik-omnivore to 9.0.0
+- Updated tilelive-bridge to 3.0.0
+- Drops windows support
+- Now uses node-mapnik 3.7.0
+
 ## 3.5.0
 
 - Upgraded mapnik-omnivore@8.5.0 (clamp rasters at z0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-omnivore",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Implements the tilelive API for a variety of raw data formats",
   "main": "index.js",
   "scripts": {
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.5.0",
-    "@mapbox/tilelive-bridge": "~2.5.0",
+    "@mapbox/mapnik-omnivore": "~8.6.0",
+    "@mapbox/tilelive-bridge": "~2.6.0",
     "queue-async": "^1.0.7",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-omnivore",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "Implements the tilelive API for a variety of raw data formats",
   "main": "index.js",
   "scripts": {
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/mapbox/tilelive-omnivore",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.6.0",
-    "@mapbox/tilelive-bridge": "~2.6.0",
+    "@mapbox/mapnik-omnivore": "~9.0.0",
+    "@mapbox/tilelive-bridge": "~3.0.0",
     "queue-async": "^1.0.7",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
Bump to `4.0.0`. Drops support for windows (if anyone was using that). Updates dependencies so that mapnik `3.7.0` is now used. 